### PR TITLE
Improve formatting of Select-String

### DIFF
--- a/Formatting/Matchinfo.format.ps1
+++ b/Formatting/Matchinfo.format.ps1
@@ -1,0 +1,55 @@
+﻿Write-FormatView -TypeName Microsoft.PowerShell.Commands.MatchInfo -Action {
+    $matchInfo = $_
+    $isFileMatch = $matchInfo.Path -and ($matchInfo.Path -ne 'InputStream')
+    $currentLocation = $ExecutionContext.SessionState.Path.CurrentLocation
+    $relativePath = $matchInfo.RelativePath($currentLocation)
+    $originalLine = $(
+        if ($matchInfo.ToEmphasizedString) {
+            $matchInfo.ToEmphasizedString($currentLocation)
+        } elseif ($isFileMatch) {
+            $matchInfo.ToString().Replace($matchInfo.Path, $relativePath)
+        } else {
+            $matchInfo.ToString()
+        }
+    )
+
+    if ($PSStyle) {
+        if ($isFileMatch) {
+            # Match in a file item
+            $colorTable = @(
+                $PSStyle.Foreground.Green
+                $PSStyle.Foreground.Yellow
+            )
+
+            $colorIndex = & $Posh {
+                # Create a module scope variable
+                if (-not $script:MatchInfoColorIndex) {
+                    $script:MatchInfoColorIndex = @{
+                        index = 0
+                        lastFilepath = $args[0]
+                    }
+                }
+                $script:MatchInfoColorIndex
+            } $relativePath
+            if ($colorIndex.lastFilepath -ne $relativePath) {
+                $colorIndex.index = ($colorIndex.index + 1) % $colorTable.Count
+                $colorIndex.lastFilepath = $relativePath
+            }
+
+            $color = $colorTable[$colorIndex.index]
+            $coloredPath = $color + $relativePath + $PSStyle.Reset
+            
+            if ($PSStyle.FormatHyperlink -and -not $env:GITHUB_WORKSPACE) {
+                $hyperLink = $PSStyle.FormatHyperlink($coloredPath, $matchInfo.Path)
+                $originalLine.Replace($relativePath, $hyperLink)
+            } else {
+                $originalLine.Replace($relativePath, $coloredPath)
+            }
+        } else {
+            # Match in a text input
+            $originalLine
+        }
+    } else {
+        $originalLine
+    }
+}

--- a/Posh.format.ps1xml
+++ b/Posh.format.ps1xml
@@ -3871,6 +3871,77 @@ if ($Request -or $Host.UI.SupportsHTML) {
       </TableControl>
     </View>
     <View>
+      <Name>Microsoft.PowerShell.Commands.MatchInfo</Name>
+      <ViewSelectedBy>
+        <TypeName>Microsoft.PowerShell.Commands.MatchInfo</TypeName>
+      </ViewSelectedBy>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+            <CustomItem>
+              <ExpressionBinding>
+                <ScriptBlock>
+    $matchInfo = $_
+    $isFileMatch = $matchInfo.Path -and ($matchInfo.Path -ne 'InputStream')
+    $currentLocation = $ExecutionContext.SessionState.Path.CurrentLocation
+    $relativePath = $matchInfo.RelativePath($currentLocation)
+    $originalLine = $(
+        if ($matchInfo.ToEmphasizedString) {
+            $matchInfo.ToEmphasizedString($currentLocation)
+        } elseif ($isFileMatch) {
+            $matchInfo.ToString().Replace($matchInfo.Path, $relativePath)
+        } else {
+            $matchInfo.ToString()
+        }
+    )
+
+    if ($PSStyle) {
+        if ($isFileMatch) {
+            # Match in a file item
+            $colorTable = @(
+                $PSStyle.Foreground.Green
+                $PSStyle.Foreground.Yellow
+            )
+
+            $colorIndex = &amp; $Posh {
+                # Create a module scope variable
+                if (-not $script:MatchInfoColorIndex) {
+                    $script:MatchInfoColorIndex = @{
+                        index = 0
+                        lastFilepath = $args[0]
+                    }
+                }
+                $script:MatchInfoColorIndex
+            } $relativePath
+            if ($colorIndex.lastFilepath -ne $relativePath) {
+                $colorIndex.index = ($colorIndex.index + 1) % $colorTable.Count
+                $colorIndex.lastFilepath = $relativePath
+            }
+
+            $color = $colorTable[$colorIndex.index]
+            $coloredPath = $color + $relativePath + $PSStyle.Reset
+            
+            if ($PSStyle.FormatHyperlink -and -not $env:GITHUB_WORKSPACE) {
+                $hyperLink = $PSStyle.FormatHyperlink($coloredPath, $matchInfo.Path)
+                $originalLine.Replace($relativePath, $hyperLink)
+            } else {
+                $originalLine.Replace($relativePath, $coloredPath)
+            }
+        } else {
+            # Match in a text input
+            $originalLine
+        }
+    } else {
+        $originalLine
+    }
+</ScriptBlock>
+              </ExpressionBinding>
+            </CustomItem>
+          </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </View>
+    <View>
       <Name>Microsoft.PowerShell.Commands.MemberDefinition</Name>
       <ViewSelectedBy>
         <TypeName>Microsoft.PowerShell.Commands.MemberDefinition</TypeName>


### PR DESCRIPTION
This PR adds clickable links and colorization to the output of Select-String (#109) .

The matched file paths alternate 2 colors.

![image](https://github.com/StartAutomating/Posh/assets/81177095/3ae57f21-951e-4968-b734-65e23c97eb8e)
