### PR TITLE
Call and store ScriptBlocks directly in Stackable functions

### DIFF
--- a/Posh.types.ps1xml
+++ b/Posh.types.ps1xml
@@ -1144,9 +1144,14 @@ param(
 $Value
 )
 
-$ToAppend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $currentFunction }; . { $toAppend}) -join ''" 
+$toAppend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $currentFunction; . $toAppend) -join ''}.GetNewClosure()
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
@@ -1205,9 +1210,14 @@ $Value
 
 
 
-$toPrepend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $toPrepend} ; . { $currentFunction }) -join ''" 
+$toPrepend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $toPrepend; . $currentFunction) -join ''}.GetNewClosure()
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
@@ -1261,27 +1271,26 @@ $Value
 
 
 $toReplace = if ($Value -is [ScriptBlock]) {
-    "{$Value}"
+    $Value
 } else {
-    $this.Stringify($Value)
+    [ScriptBlock]::Create($this.Stringify($Value))
 }
 
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 
-$replaceRegex = "[Regex]::new('$($Replace -replace "'","''")','IgnoreCase,IgnorePatternWhitespace','00:00:02')"
 $passThru = $false
 foreach ($arg in $args) {
     if ($arg -is [bool] -and $arg) {
         $passThru = $true
     }
 }
-$newFunc = "@(
-    `$existingOutput =. { $currentFunction };
-    `$replacePattern = $replaceRegex
-    `$replaceWith = $toReplace 
-    `$replacePattern.Replace(`$existingOutput, `$replaceWith)
-) -join ''" 
-
+$newFunc = {
+    @(
+        $existingOutput =. $currentFunction
+        $replaceRegex = [Regex]::new($Replace,'IgnoreCase,IgnorePatternWhitespace','00:00:02')
+        $replaceRegex.Replace($existingOutput, $toReplace)
+    ) -join ''
+}.GetNewClosure()
 
 $this.Current = $newFunc
 if ($passThru) {
@@ -1350,11 +1359,15 @@ $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($th
     $Posh.Prompt.Current = {"?"}
 #&gt;
 if (-not $this.FunctionName) { return }
-$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 $this.Stack.Push(
 $currentFunctionValue
 )
-$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", "$args")
+$newFunctionValue = $args[0]
+if ($newFunctionValue -isnot [ScriptBlock]) {
+    $newFunctionValue = [ScriptBlock]::Create($this.Stringify($newFunctionValue))
+}
+$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", $newFunctionValue)
                     </SetScriptBlock>
       </ScriptProperty>
       <NoteProperty>
@@ -2112,9 +2125,14 @@ param(
 $Value
 )
 
-$ToAppend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $currentFunction }; . { $toAppend}) -join ''" 
+$toAppend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $currentFunction; . $toAppend) -join ''}.GetNewClosure()
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
@@ -2173,9 +2191,14 @@ $Value
 
 
 
-$toPrepend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $toPrepend} ; . { $currentFunction }) -join ''" 
+$toPrepend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $toPrepend; . $currentFunction) -join ''}.GetNewClosure()
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
@@ -2229,27 +2252,26 @@ $Value
 
 
 $toReplace = if ($Value -is [ScriptBlock]) {
-    "{$Value}"
+    $Value
 } else {
-    $this.Stringify($Value)
+    [ScriptBlock]::Create($this.Stringify($Value))
 }
 
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 
-$replaceRegex = "[Regex]::new('$($Replace -replace "'","''")','IgnoreCase,IgnorePatternWhitespace','00:00:02')"
 $passThru = $false
 foreach ($arg in $args) {
     if ($arg -is [bool] -and $arg) {
         $passThru = $true
     }
 }
-$newFunc = "@(
-    `$existingOutput =. { $currentFunction };
-    `$replacePattern = $replaceRegex
-    `$replaceWith = $toReplace 
-    `$replacePattern.Replace(`$existingOutput, `$replaceWith)
-) -join ''" 
-
+$newFunc = {
+    @(
+        $existingOutput =. $currentFunction
+        $replaceRegex = [Regex]::new($Replace,'IgnoreCase,IgnorePatternWhitespace','00:00:02')
+        $replaceRegex.Replace($existingOutput, $toReplace)
+    ) -join ''
+}.GetNewClosure()
 
 $this.Current = $newFunc
 if ($passThru) {
@@ -2318,11 +2340,15 @@ $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($th
     $Posh.Prompt.Current = {"?"}
 #&gt;
 if (-not $this.FunctionName) { return }
-$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 $this.Stack.Push(
 $currentFunctionValue
 )
-$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", "$args")
+$newFunctionValue = $args[0]
+if ($newFunctionValue -isnot [ScriptBlock]) {
+    $newFunctionValue = [ScriptBlock]::Create($this.Stringify($newFunctionValue))
+}
+$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", $newFunctionValue)
                     </SetScriptBlock>
       </ScriptProperty>
       <NoteProperty>
@@ -2591,9 +2617,14 @@ param(
 $Value
 )
 
-$ToAppend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $currentFunction }; . { $toAppend}) -join ''" 
+$toAppend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $currentFunction; . $toAppend) -join ''}.GetNewClosure()
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
@@ -2652,9 +2683,14 @@ $Value
 
 
 
-$toPrepend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $toPrepend} ; . { $currentFunction }) -join ''" 
+$toPrepend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $toPrepend; . $currentFunction) -join ''}.GetNewClosure()
                     </Script>
       </ScriptMethod>
       <ScriptMethod>
@@ -2708,27 +2744,26 @@ $Value
 
 
 $toReplace = if ($Value -is [ScriptBlock]) {
-    "{$Value}"
+    $Value
 } else {
-    $this.Stringify($Value)
+    [ScriptBlock]::Create($this.Stringify($Value))
 }
 
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 
-$replaceRegex = "[Regex]::new('$($Replace -replace "'","''")','IgnoreCase,IgnorePatternWhitespace','00:00:02')"
 $passThru = $false
 foreach ($arg in $args) {
     if ($arg -is [bool] -and $arg) {
         $passThru = $true
     }
 }
-$newFunc = "@(
-    `$existingOutput =. { $currentFunction };
-    `$replacePattern = $replaceRegex
-    `$replaceWith = $toReplace 
-    `$replacePattern.Replace(`$existingOutput, `$replaceWith)
-) -join ''" 
-
+$newFunc = {
+    @(
+        $existingOutput =. $currentFunction
+        $replaceRegex = [Regex]::new($Replace,'IgnoreCase,IgnorePatternWhitespace','00:00:02')
+        $replaceRegex.Replace($existingOutput, $toReplace)
+    ) -join ''
+}.GetNewClosure()
 
 $this.Current = $newFunc
 if ($passThru) {
@@ -2797,11 +2832,15 @@ $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($th
     $Posh.Prompt.Current = {"?"}
 #&gt;
 if (-not $this.FunctionName) { return }
-$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 $this.Stack.Push(
 $currentFunctionValue
 )
-$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", "$args")
+$newFunctionValue = $args[0]
+if ($newFunctionValue -isnot [ScriptBlock]) {
+    $newFunctionValue = [ScriptBlock]::Create($this.Stringify($newFunctionValue))
+}
+$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", $newFunctionValue)
                     </SetScriptBlock>
       </ScriptProperty>
     </Members>

--- a/Types/Posh.Stackable/Append.ps1
+++ b/Types/Posh.Stackable/Append.ps1
@@ -9,6 +9,11 @@ param(
 $Value
 )
 
-$ToAppend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $currentFunction }; . { $toAppend}) -join ''" 
+$toAppend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $currentFunction; . $toAppend) -join ''}.GetNewClosure()

--- a/Types/Posh.Stackable/Prepend.ps1
+++ b/Types/Posh.Stackable/Prepend.ps1
@@ -13,6 +13,11 @@ $Value
 
 
 
-$toPrepend = $this.Stringify($Value)
-$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
-$this.Current = "@(. { $toPrepend} ; . { $currentFunction }) -join ''" 
+$toPrepend = if ($Value -is [ScriptBlock]) {
+    $Value
+} else {
+    [ScriptBlock]::Create($this.Stringify($Value))
+}
+
+$currentFunction = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
+$this.Current = {@(. $toPrepend; . $currentFunction) -join ''}.GetNewClosure()

--- a/Types/Posh.Stackable/set_Current.ps1
+++ b/Types/Posh.Stackable/set_Current.ps1
@@ -9,8 +9,12 @@
     $Posh.Prompt.Current = {"?"}
 #>
 if (-not $this.FunctionName) { return }
-$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")
+$currentFunctionValue = $posh.ExecutionContext.SessionState.InvokeCommand.InvokeScript("`$function:$($this.FunctionName)")[0]
 $this.Stack.Push(
 $currentFunctionValue
 )
-$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", "$args")
+$newFunctionValue = $args[0]
+if ($newFunctionValue -isnot [ScriptBlock]) {
+    $newFunctionValue = [ScriptBlock]::Create($this.Stringify($newFunctionValue))
+}
+$posh.ExecutionContext.SessionState.PSVariable.Set("function:$($this.FunctionName)", $newFunctionValue)


### PR DESCRIPTION
This PR fixes #138.

By capturing the ScriptBlocks passed to Append/Prepend/Replace in stead of stringifying them, it keeps the SessionState where the ScriptBlocks are created which for example makes it possible for the users to customize Prompt in a module and stack it.

```powershell
# MyModule.psm1
$moduleVar = 'Hello > '
$function:global:Prompt = {
    $moduleVar
}
```

Import MyModule and Posh, then call Append.

```powershell
PS > Import-Module ./MyModule.psm1
Hello > Import-Module Posh
Hello > $Posh.Prompt.Append('!!  ')
Hello > !! 
```
This produces an expected result `Hello > !!` while it shows `!! ` with the current version.